### PR TITLE
Update Redis plugin to use SCAN instead of KEYS

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"fmt"
-	// "fmt"
 	"time"
 
 	"github.com/coredns/coredns/plugin"

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -213,6 +213,8 @@ func newRedisPlugin() *Redis {
 	*/
 }
 
+// TestAnswer is an integration test which requires a local Redis instance. The test
+// expects an instance on localhost:6379 configured without authentication.
 func TestAnswer(t *testing.T) {
 	fmt.Println("lookup test")
 	r := newRedisPlugin()
@@ -240,7 +242,9 @@ func TestAnswer(t *testing.T) {
 			if resp == nil {
 				resp = new(dns.Msg)
 			}
-			test.SortAndCheck(t, resp, tc)
+			if err := test.SortAndCheck(resp, tc); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }

--- a/redis.go
+++ b/redis.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/miekg/dns"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +27,11 @@ type Redis struct {
 	LastZoneUpdate time.Time
 }
 
+type RedisScanReply struct {
+	cursor int
+	keys   []string
+}
+
 func (redis *Redis) LoadZones() {
 	var (
 		reply interface{}
@@ -40,15 +46,48 @@ func (redis *Redis) LoadZones() {
 	}
 	defer conn.Close()
 
-	reply, err = conn.Do("KEYS", redis.keyPrefix + "*" + redis.keySuffix)
-	if err != nil {
-		return
+	matchPattern := redis.keyPrefix + "*" + redis.keySuffix
+
+	/*
+		SCAN is a cursor based iterator. This means that at every call of the command,
+		the server returns an updated cursor that the user needs to use as the cursor
+		argument in the next call.
+		https://redis.io/docs/latest/commands/scan
+	*/
+	cursor := 0
+	cursorBatchSize := 1000
+	keysSeen := map[string]bool{}
+	for {
+		reply, err = conn.Do("SCAN", cursor, "MATCH", matchPattern, "COUNT", cursorBatchSize)
+		if err != nil {
+			return
+		}
+
+		scanReply, err := decodeScanReply(reply)
+		if err != nil {
+			return
+		}
+		cursor = scanReply.cursor
+
+		for _, zone := range scanReply.keys {
+			// Note: a given element may be returned multiple times. It is up to
+			// the application to handle the case of duplicated elements
+			if _, found := keysSeen[zone]; !found {
+
+				zone = strings.TrimPrefix(zone, redis.keyPrefix)
+				zone = strings.TrimPrefix(zone, redis.keySuffix)
+
+				zones = append(zones, zone)
+				keysSeen[zone] = true
+			}
+		}
+
+		// Cursor will be 0 after all keys have been read
+		if cursor == 0 {
+			break
+		}
 	}
-	zones, err = redisCon.Strings(reply, nil)
-	for i, _ := range zones {
-		zones[i] = strings.TrimPrefix(zones[i], redis.keyPrefix)
-		zones[i] = strings.TrimSuffix(zones[i], redis.keySuffix)
-	}
+
 	redis.LastZoneUpdate = time.Now()
 	redis.Zones = zones
 }
@@ -466,6 +505,35 @@ func (redis *Redis) load(zone string) *Zone {
 	}
 
 	return z
+}
+
+// decodeScanReply parses redigo's response from the SCAN command and returns it as
+// structured data.
+func decodeScanReply(reply interface{}) (scanReply *RedisScanReply, err error) {
+	scanReply = &RedisScanReply{}
+
+	// Redigo encodes the reply as an interface{}, so here we are converting it to something
+	// useful.  Under the covers, the reply is [][]byte{}.
+
+	// the cursor is []byte encoded in index 0
+	cursorBytes := reply.([]interface{})[0].([]uint8)
+	cursor, err := strconv.Atoi(string(cursorBytes))
+	if err != nil {
+		return nil, err
+	}
+	scanReply.cursor = cursor
+
+	// keys are []byte encoded starting with index 1
+	for _, value := range reply.([]interface{})[1:] {
+
+		redisKeys := value.([]interface{})
+		for _, redisKey := range redisKeys {
+
+			zone := string(redisKey.([]uint8))
+			scanReply.keys = append(scanReply.keys, zone)
+		}
+	}
+	return scanReply, nil
 }
 
 func split255(s string) []string {


### PR DESCRIPTION
# Overview
<!--- What will be the result of this change? Did you fix a bug, introduce a new feature, or change existing functionality? --->
Per Redis' docs, the [KEYS](https://redis.io/docs/latest/commands/keys/) command may ruin performance when executed against large databases and should not be used in regular application code.  [SCAN](https://redis.io/docs/latest/commands/scan/) is the safe alternative with an identical pattern-based match.  This PR updates the plugin to use SCAN instead of KEYS.

SCAN is used by the plugin to dynamically learn of configured zones at startup and periodically.

## Description
<!--- Please describe your change in enough detail that another engineer could understand what was changed before reviewing the source code. --->

* The Redis `SCAN` command operates like a pagination feature.  Instead of receiving the entire set of results in one response, a subset roughly equivalent in size to the `COUNT` parameter is returned.  In addition, a numeric `cursor` value is returned.  When executing the `SCAN` command, one needs to specify the `cursor` value.  On the first request, it is set to 0.  Successive requests pass the previously returned `cursor` value.  When there are multiple "pages" or batches worth or replies, the cursor increments numerically.  When all results have been returned, the cursor is reset to 0 and a 0 value is returned.

* In `redis.go`'s `LoadZones()`, the use of `KEYS` was replaced with `SCAN`.  A loop was introduced to convert from a single response to a paginated one.  

* As Redis maintains little to no state regarding `SCAN` requests, duplicates may be observed across responses.  In this PR, there is a deduplication step when processing responses to handle that.

* A function named `decodeScanReply()` was added to handle processing of [Redigo's](https://github.com/gomodule/redigo) response for `SCAN`.  Unfortunately, that package encodes the response as an `interface{}`, with another layer of `interface{}` and ultimately byte encoding the contents.  This required a deep level of massaging.  I attempted to use Redigo's [`ByteSlices()` ](https://github.com/gomodule/redigo/blob/master/redis/reply.go#L321) and [`Byte()` ](https://github.com/gomodule/redigo/blob/master/redis/reply.go#L178C6-L178C11) but was not successful with either.  The `SCAN` response data is encoded differently than either support.  In a future PR, I will propose the replacement of Redigo with Redis' official Go client.  The official Go Client exposes a function named [`Scan()`](https://github.com/redis/go-redis/blob/master/command.go#L921) which provides a much more elegant response.

## Testing Approach and Results
<!--- How did you test this change? Please provide exact commands and steps used to test so that your reviewer can test as well. --->

### Manual Testing
For manual testing, I copied my local copy of this repo into a local checkout of CoreDNS' own repo under `plugin/redislocal`.  In CoreDNS' `plugin.cfg`, I had added:
```
redis:redislocal
```
Then, I ran `make coredns`.

In another terminal, I started CoreDNS using the following `Corefile`:

**Corefile**
```
.:1053 {
    log
    errors
    redis {
        address localhost:6379
        connect_timeout 100
        read_timeout 100
        ttl 30
        prefix ""
    }
    debug
}
```

**Populating Redis**
```
127.0.0.1:6379> flushdb
OK
127.0.0.1:6379> hset example.net. host1 "{\"a\":[{\"ttl\":300, \"ip\":\"1.1.1.1\"}]}"
(integer) 1
127.0.0.1:6379> hset example.net. host2 "{\"a\":[{\"ttl\":300, \"ip\":\"2.2.2.2\"}]}"
(integer) 1
127.0.0.1:6379> hset example.com. hosta "{\"aaaa\":[{\"ttl\":300, \"ip\":\"2601::a\"}]}"
(integer) 1
127.0.0.1:6379> hset example.com. hostb "{\"aaaa\":[{\"ttl\":300, \"ip\":\"2601::b\"}]}"
(integer) 1
```

**Dig for host1**
```
$  dig localhost -p 1053 host1.example.net

; <<>> DiG 9.18.24-0ubuntu0.22.04.1-Ubuntu <<>> localhost -p 1053 host1.example.net
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 8698
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 98e9a4b60d5580b0 (echoed)
;; QUESTION SECTION:
;localhost.                     IN      A

;; Query time: 4 msec
;; SERVER: 127.0.0.53#1053(127.0.0.53) (UDP)
;; WHEN: Mon Sep 09 18:30:54 PDT 2024
;; MSG SIZE  rcvd: 50

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12282
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 98e9a4b60d5580b0 (echoed)
;; QUESTION SECTION:
;host1.example.net.             IN      A

;; ANSWER SECTION:
host1.example.net.      30      IN      A       1.1.1.1

;; Query time: 0 msec
;; SERVER: 127.0.0.53#1053(127.0.0.53) (UDP)
;; WHEN: Mon Sep 09 18:30:54 PDT 2024
;; MSG SIZE  rcvd: 91
```

### Unit Tests

One issue was corrected with the existing test related to a function signature change on [`test.ScanAndCheck()`](https://github.com/coredns/coredns/blob/master/plugin/test/helpers.go#L279).  I considered adding a test for `decodeScanReply()`, but held off as I plan to prepare another PR shortly after to swap to the official Redis client which eliminates the need for that function.

```
$  go test -v
=== RUN   TestAnswer
lookup test
--- PASS: TestAnswer (0.03s)
PASS
ok      redis   0.044s
```

While the test was running, I captured the local Redis instance's activity using the `MONITOR` command:
```
$  docker exec  -ti dns-redis-1 redis-cli
127.0.0.1:6379> monitor
OK
1725929730.247790 [0 172.22.0.1:56354] "SCAN" "0" "MATCH" "*" "COUNT" "1000"
1725929730.248682 [0 172.22.0.1:56370] "EVAL" "return redis.call('del', unpack(redis.call('keys', ARGV[1])))" "0" "example.com."
1725929730.249007 [0 lua] "keys" "example.com."
1725929730.249071 [0 lua] "del" "example.com."
1725929730.249702 [0 172.22.0.1:56380] "HSET" "example.com." "@" "{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.com.\",\"ns\":\"ns1.example.com.\",\"refresh\":44,\"retry\":55,\"expire\":66}}"
1725929730.250454 [0 172.22.0.1:56386] "HSET" "example.com." "x" "{\"a\":[{\"ttl\":300, \"ip\":\"1.2.3.4\"},{\"ttl\":300, \"ip\":\"5.6.7.8\"}],\"aaaa\":[{\"ttl\":300, \"ip\":\"::1\"}],\"txt\":[{\"ttl\":300, \"text\":\"foo\"},{\"ttl\":300, \"text\":\"bar\"}],\"ns\":[{\"ttl\":300, \"host\":\"ns1.example.com.\"},{\"ttl\":300, \"host\":\"ns2.example.com.\"}],\"mx\":[{\"ttl\":300, \"host\":\"mx1.example.com.\", \"preference\":10},{\"ttl\":300, \"host\":\"mx2.example.com.\", \"preference\":10}]}"
1725929730.251131 [0 172.22.0.1:56394] "HSET" "example.com." "y" "{\"cname\":[{\"ttl\":300, \"host\":\"x.example.com.\"}]}"
1725929730.251744 [0 172.22.0.1:56410] "HSET" "example.com." "ns1" "{\"a\":[{\"ttl\":300, \"ip\":\"2.2.2.2\"}]}"
1725929730.252308 [0 172.22.0.1:56418] "HSET" "example.com." "ns2" "{\"a\":[{\"ttl\":300, \"ip\":\"3.3.3.3\"}]}"
1725929730.252891 [0 172.22.0.1:56420] "HSET" "example.com." "_sip._tcp" "{\"srv\":[{\"ttl\":300, \"target\":\"sip.example.com.\",\"port\":555,\"priority\":10,\"weight\":100}]}"
1725929730.253431 [0 172.22.0.1:56424] "HSET" "example.com." "sip" "{\"a\":[{\"ttl\":300, \"ip\":\"7.7.7.7\"}],\"aaaa\":[{\"ttl\":300, \"ip\":\"::1\"}]}"
1725929730.254062 [0 172.22.0.1:56438] "HKEYS" "example.com."
1725929730.254640 [0 172.22.0.1:56440] "HGET" "example.com." "x"
1725929730.255614 [0 172.22.0.1:56450] "HKEYS" "example.com."
1725929730.256205 [0 172.22.0.1:56458] "HGET" "example.com." "x"
1725929730.256863 [0 172.22.0.1:56470] "HKEYS" "example.com."
1725929730.257468 [0 172.22.0.1:56476] "HGET" "example.com." "x"
1725929730.258083 [0 172.22.0.1:56486] "HKEYS" "example.com."
1725929730.259226 [0 172.22.0.1:56502] "HGET" "example.com." "y"
1725929730.259786 [0 172.22.0.1:56508] "HKEYS" "example.com."
1725929730.260333 [0 172.22.0.1:56522] "HGET" "example.com." "x"
1725929730.260940 [0 172.22.0.1:56538] "HGET" "example.com." "ns1"
1725929730.261494 [0 172.22.0.1:56540] "HGET" "example.com." "ns2"
1725929730.262085 [0 172.22.0.1:56550] "HKEYS" "example.com."
1725929730.262608 [0 172.22.0.1:56558] "HGET" "example.com." "x"
1725929730.263194 [0 172.22.0.1:56564] "HKEYS" "example.com."
1725929730.263756 [0 172.22.0.1:56568] "HGET" "example.com." "_sip._tcp"
1725929730.264292 [0 172.22.0.1:56574] "HGET" "example.com." "sip"
1725929730.264940 [0 172.22.0.1:56584] "HKEYS" "example.com."
1725929730.265488 [0 172.22.0.1:56586] "HKEYS" "example.com."
1725929730.266052 [0 172.22.0.1:56588] "HGET" "example.com." "@"
1725929730.266366 [0 172.22.0.1:56370] "EVAL" "return redis.call('del', unpack(redis.call('keys', ARGV[1])))" "0" "example.net."
1725929730.266398 [0 lua] "keys" "example.net."
1725929730.266418 [0 lua] "del" "example.net."
1725929730.266933 [0 172.22.0.1:56600] "HSET" "example.net." "@" "{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.net.\",\"ns\":\"ns1.example.net.\",\"refresh\":44,\"retry\":55,\"expire\":66},\"ns\":[{\"ttl\":300, \"host\":\"ns1.example.net.\"},{\"ttl\":300, \"host\":\"ns2.example.net.\"}]}"
1725929730.267538 [0 172.22.0.1:56602] "HSET" "example.net." "sub.*" "{\"txt\":[{\"ttl\":300, \"text\":\"this is not a wildcard\"}]}"
1725929730.268091 [0 172.22.0.1:56604] "HSET" "example.net." "host1" "{\"a\":[{\"ttl\":300, \"ip\":\"5.5.5.5\"}]}"
1725929730.268649 [0 172.22.0.1:56608] "HSET" "example.net." "subdel" "{\"ns\":[{\"ttl\":300, \"host\":\"ns1.subdel.example.net.\"},{\"ttl\":300, \"host\":\"ns2.subdel.example.net.\"}]}"
1725929730.269222 [0 172.22.0.1:56612] "HSET" "example.net." "*" "{\"txt\":[{\"ttl\":300, \"text\":\"this is a wildcard\"}],\"mx\":[{\"ttl\":300, \"host\":\"host1.example.net.\",\"preference\": 10}]}"
1725929730.269807 [0 172.22.0.1:56626] "HSET" "example.net." "_ssh._tcp.host1" "{\"srv\":[{\"ttl\":300, \"target\":\"tcp.example.com.\",\"port\":123,\"priority\":10,\"weight\":100}]}"
1725929730.270349 [0 172.22.0.1:56632] "HSET" "example.net." "_ssh._tcp.host2" "{\"srv\":[{\"ttl\":300, \"target\":\"tcp.example.com.\",\"port\":123,\"priority\":10,\"weight\":100}]}"
1725929730.270939 [0 172.22.0.1:56650] "HKEYS" "example.net."
1725929730.271577 [0 172.22.0.1:56654] "HGET" "example.net." "*"
1725929730.272385 [0 172.22.0.1:56670] "HGET" "example.net." "host1"
1725929730.272944 [0 172.22.0.1:56684] "HKEYS" "example.net."
1725929730.273482 [0 172.22.0.1:56692] "HGET" "example.net." "*"
1725929730.274056 [0 172.22.0.1:56706] "HKEYS" "example.net."
1725929730.274563 [0 172.22.0.1:56720] "HGET" "example.net." "*"
1725929730.275169 [0 172.22.0.1:56724] "HKEYS" "example.net."
1725929730.275779 [0 172.22.0.1:56728] "HGET" "example.net." "host1"
1725929730.276430 [0 172.22.0.1:56740] "HKEYS" "example.net."
1725929730.276984 [0 172.22.0.1:56746] "HGET" "example.net." "sub.*"
1725929730.277515 [0 172.22.0.1:56756] "HKEYS" "example.net."
1725929730.278068 [0 172.22.0.1:56760] "HKEYS" "example.net."
1725929730.278584 [0 172.22.0.1:56772] "HKEYS" "example.net."
1725929730.279189 [0 172.22.0.1:56782] "HGET" "example.net." "*"
```

