### PR TITLE
Fix nil panic from JSON-decoding error

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -74,6 +74,10 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	extras := make([]dns.RR, 0, 10)
 
 	record := redis.get(location, z)
+	if record == nil {
+		// Record may be nil when the redis read returns an error
+		return redis.errorResponse(state, zone, dns.RcodeServerFailure, nil)
+	}
 
 	switch qtype {
 	case "A":

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -16,6 +16,7 @@ var zones = []string {
 }
 
 var lookupEntries = [][][]string {
+	// Example.com
 	{
 		{"@",
 			"{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.com.\",\"ns\":\"ns1.example.com.\",\"refresh\":44,\"retry\":55,\"expire\":66}}",
@@ -44,6 +45,7 @@ var lookupEntries = [][][]string {
 			"\"aaaa\":[{\"ttl\":300, \"ip\":\"::1\"}]}",
 		},
 	},
+	// Example.net
 	{
 		{"@",
 			"{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.net.\",\"ns\":\"ns1.example.net.\",\"refresh\":44,\"retry\":55,\"expire\":66}," +
@@ -67,6 +69,17 @@ var lookupEntries = [][][]string {
 		},
 		{"_ssh._tcp.host2",
 			"{\"srv\":[{\"ttl\":300, \"target\":\"tcp.example.com.\",\"port\":123,\"priority\":10,\"weight\":100}]}",
+		},
+	},
+	// Example.test
+	{
+		{"@",
+			"{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.test.\",\"ns\":\"ns1.example.test.\",\"refresh\":44,\"retry\":55,\"expire\":66}," +
+				"\"ns\":[{\"ttl\":300, \"host\":\"ns1.example.test.\"},{\"ttl\":300, \"host\":\"ns2.example.test.\"}]}",
+		},
+		// Host1's IP field contains invalid JSON
+		{"host1",
+			"{\"a\":[{\"ttl\":300, \"ip\":\"5.5.5.5\"}",
 		},
 	},
 }
@@ -189,6 +202,13 @@ var testCases = [][]test.Case{
 			},
 		},
 	},
+	// Malformed data tests
+	{
+		{
+			Qname: "host1.example.test.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeServerFailure,
+		},
+	},
 }
 
 func newRedisPlugin() *Redis {
@@ -240,7 +260,9 @@ func TestAnswer(t *testing.T) {
 			if resp == nil {
 				resp = new(dns.Msg)
 			}
-			test.SortAndCheck(t, resp, tc)
+			if err := test.SortAndCheck(resp, tc); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Overview
<!--- What will be the result of this change? Did you fix a bug, introduce a new feature, or change existing functionality? --->
When the value for a given Redis key is not in proper JSON-format, the plugin causes a `nil` panic crash for the associated CoreDNS instance.  This PR adds a `nil` check and returns an error to the DNS client instead.

## Description
<!--- Please describe your change in enough detail that another engineer could understand what was changed before reviewing the source code. --->

### Repro

In my local Redis instance, one record contained malformed JSON:
```
3) "hostb"
4) "{\"aaaa\":[{\"ttl\":300, \"ip\":\"2601::b\"}"
```
(the value for `ip` is malformed)

A query for this host triggered the `nil` panic shown below:

```
CoreDNS-1.11.3
linux/amd64, go1.23.0, 289e3e7af-dirty
parse error :  {"aaaa":[{"ttl":300, "ip":"2601::b"} unexpected end of JSON input
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1adc012]

goroutine 90 [running]:
github.com/coredns/coredns/plugin/redislocal.(*Redis).A(0xc000036640, {0xc000546078, 0x12}, 0xc0006b22a0?, 0x12?)
        coredns/plugin/redislocal/redis.go:57 +0x32
github.com/coredns/coredns/plugin/redislocal.(*Redis).ServeDNS(0xc000036640, {0x291bdf0, 0xc0007d3620}, {0x2925b38, 0xc000034840}, 0xc00056bb90)
        coredns/plugin/redislocal/handler.go:80 +0x3ff
github.com/coredns/coredns/plugin.NextOrFailure({0x244a3e1?, 0x1?}, {0x2903138, 0xc000036640}, {0x291bdf0, 0xc0007d3620}, {0x2925b38, 0xc000034840}, 0xc00056bb90)
        coredns/plugin/plugin.go:80 +0x273
github.com/coredns/coredns/plugin/log.Logger.ServeDNS({{0x2903138, 0xc000036640}, {0xc00081f4d0, 0x1, 0x1}, {}}, {0x291bdf0, 0xc0007d3620}, {0x2926320, 0xc0006b21c8}, ...)
        coredns/plugin/log/log.go:36 +0x2bf
github.com/coredns/coredns/plugin.NextOrFailure({0x244ca0b?, 0x554d?}, {0x2903070, 0xc00081fc20}, {0x291bdf0, 0xc0007d3620}, {0x2926320, 0xc0006b21c8}, 0xc00056bb90)
        coredns/plugin/plugin.go:80 +0x273
github.com/coredns/coredns/plugin/errors.(*errorHandler).ServeDNS(0xc00081f470, {0x291bdf0?, 0xc0007d3620?}, {0x2926320, 0xc0006b21c8}, 0xc00056bb90)
        coredns/plugin/errors/errors.go:84 +0x7b
github.com/coredns/coredns/core/dnsserver.(*Server).ServeDNS(0xc000196e00, {0x291bdf0, 0xc0007d3620}, {0x2926320, 0xc0006b21c8}, 0xc00056bb90)
        coredns/core/dnsserver/server.go:364 +0x806
github.com/coredns/coredns/core/dnsserver.(*Server).ServePacket.func1({0x2927a88, 0xc0006a2080}, 0xc00056bb90)
        coredns/core/dnsserver/server.go:178 +0x8e
github.com/miekg/dns.HandlerFunc.ServeDNS(0xc000228400?, {0x2927a88?, 0xc0006a2080?}, 0xc00056bb90?)
        go/pkg/mod/github.com/miekg/dns@v1.1.62/server.go:37 +0x29
github.com/miekg/dns.(*Server).serveDNS(0xc0006d0120, {0xc000228400, 0x3a, 0x200}, 0xc0006a2080)
        go/pkg/mod/github.com/miekg/dns@v1.1.62/server.go:680 +0x44d
github.com/miekg/dns.(*Server).serveUDPPacket(0xc0006d0120, 0xc0008a6050, {0xc000228400, 0x3a, 0x200}, {0x2923a20, 0xc000560178}, 0xc0006c0020, {0x0, 0x0})
        go/pkg/mod/github.com/miekg/dns@v1.1.62/server.go:621 +0x1a5
created by github.com/miekg/dns.(*Server).serveUDP in goroutine 14
        go/pkg/mod/github.com/miekg/dns@v1.1.62/server.go:551 +0x41a
```

As seen in:
```
parse error :  {"aaaa":[{"ttl":300, "ip":"2601::b"} unexpected end of JSON input
```
Which is a log line printed from https://github.com/codysnider/coredns-redis/blob/master/redis.go#L366 just after calling `json.Unmarshal()`.  In the handling of the original error, `nil` is returned.

The `nil` panic was experienced because consumers of this function do not check for `nil` and assume that the request returned a record.

In `handler.go`, I added a `nil` check.  As this section of code only triggers when Redis contains a match for the zone in question, I chose to return the DNS error of `Server Fail` here.

## Testing Approach and Results
<!--- How did you test this change? Please provide exact commands and steps used to test so that your reviewer can test as well. --->

### Manual Testing
Locally, I no longer see a `nil` panic and the CoreDNS instance continues to run.  Testing:

**Dig**
```
$  dig hostb.example.com -p 1053 V

; <<>> DiG 9.18.24-0ubuntu0.22.04.1-Ubuntu <<>> hostb.example.com -p 1053 V
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 10239
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 3ac30a0399cd3496 (echoed)
;; QUESTION SECTION:
;hostb.example.com.             IN      A

;; Query time: 0 msec
;; SERVER: 127.0.0.53#1053(127.0.0.53) (UDP)
;; WHEN: Tue Sep 10 13:58:18 PDT 2024
;; MSG SIZE  rcvd: 58

;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 28523
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 3ac30a0399cd3496 (echoed)
;; QUESTION SECTION:
;V.                             IN      A

;; Query time: 0 msec
;; SERVER: 127.0.0.53#1053(127.0.0.53) (UDP)
;; WHEN: Tue Sep 10 13:58:18 PDT 2024
;; MSG SIZE  rcvd: 42
```

**CoreDNS Logs**
```
.:1053
CoreDNS-1.11.3
linux/amd64, go1.23.0, 289e3e7af-dirty
[ERROR] plugin/redis: JSON-decoding error for redis key "example.com.": unexpected end of JSON input
[INFO] 127.0.0.1:47134 - 52068 "A IN hostb.example.com. udp 58 false 1232" SERVFAIL qr,aa,rd 58 0.002112936s
[INFO] 127.0.0.1:42363 - 33486 "A IN v. udp 42 false 1232" - - 0 0.000025377s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[ERROR] plugin/redis: JSON-decoding error for redis key "example.com.": unexpected end of JSON input
[INFO] 127.0.0.1:48437 - 46371 "A IN hostb.example.com. udp 58 false 1232" SERVFAIL qr,aa,rd 58 0.001450232s
[INFO] 127.0.0.1:37673 - 58765 "A IN v. udp 42 false 1232" - - 0 0.0000281s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[ERROR] plugin/redis: JSON-decoding error for redis key "example.com.": unexpected end of JSON input
[INFO] 127.0.0.1:51635 - 27991 "A IN hostb.example.com. udp 58 false 1232" SERVFAIL qr,aa,rd 58 0.001389061s
[INFO] 127.0.0.1:51847 - 41251 "A IN v. udp 42 false 1232" - - 0 0.000018597s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[INFO] 127.0.0.1:41752 - 55759 "A IN host1.example.net. udp 58 false 1232" NOERROR qr,aa,rd 91 0.00319291s
[INFO] 127.0.0.1:57714 - 15313 "A IN v. udp 42 false 1232" - - 0 0.000050222s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[INFO] 127.0.0.1:38958 - 58800 "A IN host1.example.net. udp 58 false 1232" NOERROR qr,aa,rd 91 0.001385808s
[INFO] 127.0.0.1:34217 - 26141 "A IN v. udp 42 false 1232" - - 0 0.000029762s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[INFO] 127.0.0.1:54215 - 42590 "A IN host1.example.net. udp 58 false 1232" NOERROR qr,aa,rd 91 0.001391678s
[INFO] 127.0.0.1:46160 - 4290 "A IN v. udp 42 false 1232" - - 0 0.000023081s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
[INFO] 127.0.0.1:35677 - 23656 "A IN host2.example.net. udp 58 false 1232" NOERROR qr,aa,rd 58 0.001368923s
[INFO] 127.0.0.1:35617 - 21111 "A IN v. udp 42 false 1232" - - 0 0.000028899s
[ERROR] plugin/errors: 2 v. A: plugin/v.: no next plugin found
```

### Unit Tests

A new test case was added with a record containing malformed JSON.

```
$  go test -v .
=== RUN   TestAnswer
lookup test
--- PASS: TestAnswer (0.03s)
PASS
ok      redis   (cached)
```