### PR TITLE
Use a logger instead of print

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1,8 +1,6 @@
 package redis
 
 import (
-	"fmt"
-	// "fmt"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -23,7 +21,6 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	}
 
 	zone := plugin.Zones(redis.Zones).Matches(qname)
-	// fmt.Println("zone : ", zone)
 	if zone == "" {
 		return plugin.NextOrFailure(qname, redis.Next, ctx, w, r)
 	}
@@ -59,7 +56,7 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 		err := tr.Out(w, r, ch)
 		if err != nil {
-			fmt.Println(err)
+			log.Error(err)
 		}
 		w.Hijack()
 		return dns.RcodeSuccess, nil

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -3,7 +3,6 @@ package redis
 import (
 	"context"
 	"testing"
-	"fmt"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
@@ -214,7 +213,6 @@ func newRedisPlugin() *Redis {
 }
 
 func TestAnswer(t *testing.T) {
-	fmt.Println("lookup test")
 	r := newRedisPlugin()
 	conn := r.Pool.Get()
 	defer conn.Close()
@@ -224,7 +222,7 @@ func TestAnswer(t *testing.T) {
 		for _, cmd := range lookupEntries[i] {
 			err := r.save(zone, cmd[0], cmd[1])
 			if err != nil {
-				fmt.Println("error in redis", err)
+				t.Error("error in redis", err)
 				t.Fail()
 			}
 		}

--- a/redis.go
+++ b/redis.go
@@ -2,15 +2,17 @@ package redis
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/miekg/dns"
 	"strings"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/miekg/dns"
 
 	redisCon "github.com/gomodule/redigo/redis"
 )
+
+var log = clog.NewWithPlugin("redis")
 
 type Redis struct {
 	Next           plugin.Handler
@@ -35,7 +37,7 @@ func (redis *Redis) LoadZones() {
 
 	conn := redis.Pool.Get()
 	if conn == nil {
-		fmt.Println("error connecting to redis")
+		log.Error("error connecting to redis")
 		return
 	}
 	defer conn.Close()
@@ -255,7 +257,7 @@ func (redis *Redis) AXFR(z *Zone) (records []dns.RR) {
 	records = append(records, extras...)
 	records = append(records, soa...)
 
-	fmt.Println(records)
+	log.Debug(records)
  	return
 }
 
@@ -340,7 +342,7 @@ func (redis *Redis) get(key string, z *Zone) *Record {
 	)
 	conn := redis.Pool.Get()
 	if conn == nil {
-		fmt.Println("error connecting to redis")
+		log.Error("error connecting to redis")
 		return nil
 	}
 	defer conn.Close()
@@ -363,7 +365,7 @@ func (redis *Redis) get(key string, z *Zone) *Record {
 	r := new(Record)
 	err = json.Unmarshal([]byte(val), r)
 	if err != nil {
-		fmt.Println("parse error : ", val, err)
+		log.Error("parse error : ", val, err)
 		return nil
 	}
 	return r
@@ -427,7 +429,7 @@ func (redis *Redis) save(zone string, subdomain string, value string) error {
 
 	conn := redis.Pool.Get()
 	if conn == nil {
-		fmt.Println("error connecting to redis")
+		log.Error("error connecting to redis")
 		return nil
 	}
 	defer conn.Close()
@@ -445,7 +447,7 @@ func (redis *Redis) load(zone string) *Zone {
 
 	conn := redis.Pool.Get()
 	if conn == nil {
-		fmt.Println("error connecting to redis")
+		log.Error("error connecting to redis")
 		return nil
 	}
 	defer conn.Close()


### PR DESCRIPTION
# Overview
<!--- What will be the result of this change? Did you fix a bug, introduce a new feature, or change existing functionality? --->
CoreDNS' plugin example uses a CoreDNS specific logger for various error messages (https://github.com/coredns/example/blob/master/example.go#L18).  This PR updates the Redis plugin to use that approach instead of various print statements.

## Description
<!--- Please describe your change in enough detail that another engineer could understand what was changed before reviewing the source code. --->
Same as above.

## Testing Approach and Results
<!--- How did you test this change? Please provide exact commands and steps used to test so that your reviewer can test as well. --->

### Manual Testing
As seen in the log message below, logs written by the Redis plugin's logger now appear with the prefix `plugin/redis`:
```
[ERROR] plugin/redis: JSON-decoding error for redis key "example.com.": unexpected end of JSON input
[INFO] 127.0.0.1:48437 - 46371 "A IN hostb.example.com. udp 58 false 1232" SERVFAIL qr,aa,rd 58 0.001450232s
``` 

### Unit Tests
```
$  go test -v
=== RUN   TestAnswer
--- PASS: TestAnswer (0.03s)
PASS
ok      redis   0.044s
```