### PR TITLE
Enable refreshing zone on keysize change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 *redis* enables reading zone data from redis database.
 this plugin should be located right next to *etcd* in *plugins.cfg*
 
+...
+secondary:secondary
+etcd:etcd
+redis:github.com/rverst/coredns-redis/plugin
+loop:loop
+forward:forward
+grpc:grpc
+...
+
+## Changes
+This fork enables dynamically loading of zone from redis as soon as zone is created instead of reloading of zones every 10 minutes. If there are no changes, then zones will reloaded every 10 minutes. There should be a way to notify redis plugin to reload zones, but right now this is the best way to deal with this.
+
 ## syntax
 
 ~~~

--- a/handler.go
+++ b/handler.go
@@ -18,7 +18,7 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	qname := state.Name()
 	qtype := state.Type()
 
-	if time.Since(redis.LastZoneUpdate) > zoneUpdateTime {
+	if time.Since(redis.LastZoneUpdate) > zoneUpdateTime || redis.lastKeyCount != redis.KeyCount() {
 		redis.LoadZones()
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -39,18 +38,18 @@ func (redis *Redis) KeyCount() int {
 	)
 	conn := redis.Pool.Get()
 	if conn == nil {
-		fmt.Println("error connecting to redis")
+		log.Error("error connecting to redis")
 		return -1;
 	}
 	defer conn.Close()
 	reply, err = conn.Do("DBSIZE")
 	if err != nil {
-		fmt.Println("error getting dbsize from redis:", err)
+		log.Error("error getting dbsize from redis:", err)
 		return -1;
 	}
 	dbsize, err := redisCon.Int(reply, nil)
 	if err != nil {
-		fmt.Println("error parsing dbsize:", err)
+		log.Error("error parsing dbsize:", err)
 		 return -1
 	}
 	return dbsize;
@@ -67,7 +66,7 @@ func (redis *Redis) LoadZones() {
 		zones []string
 	)
 
-	fmt.Println("loading zones")
+	log.Debug("loading zones")
 
 	conn := redis.Pool.Get()
 	if conn == nil {


### PR DESCRIPTION
If we add a zone dynamically - that might be required in some cases, when you are dealing with multiple sub domain, this lookup redis for keysize and then reloads all the zone.

I have merged upstream code and incorporated all changes from this pull request - please merge 

https://github.com/codysnider/coredns-redis/pull/2

I have also checked this in my setup.